### PR TITLE
feat: Add test suites

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -3,9 +3,17 @@ if [ -d "build" ]; then
 fi
 mkdir build
 cp -r src build/src
+cp -r tests build/tests
 cd build/src
-g++ -std=c++20 luna.cpp shell.cpp command.cpp -o luna.sh
-if  [[ $1 = "--debug" ]]; then
+g++ -std=c++20 luna.cpp shell.cpp command.cpp ../tests/test.cpp -o luna.sh
+if [[ $1 = "--testing" ]]; then
+    export "LUNA_TESTING_ON"=
+    echo "Hello world\n" >> ../cat_testing.txt
+    mkdir mv_test_dir
+else
+    unset "LUNA_TESTING_ON" # unset in case testing mode was ran before
+fi
+if [[ $1 = "--debug" ]]; then
     lldb ./luna.sh
 else
     ./luna.sh

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -23,7 +23,7 @@ Command::~Command() {
 void EchoCommand::echo_fn() {
     if (num_tokens > 1) {
         for (size_t i = 1; i < num_tokens; i ++) {
-            cout << command_tokens[i] << " ";
+            result = result + command_tokens[i] + " ";
         }
     }
 }
@@ -36,12 +36,12 @@ void EchoCommand::echo_fn() {
  */
 void PwdCommand::pwd_fn() {
     if (num_tokens > 1) {
-        cout << "pwd: Only write pwd!" << "\n";
+        result = "pwd: Only write pwd!\n";
         return;
     }
     string fullpath = fs::current_path();
     size_t first_quotation = fullpath.find("\"");
-    cout << fullpath.substr(first_quotation + 1, fullpath.size() - first_quotation - 1) << "\n";
+    result = fullpath.substr(first_quotation + 1, fullpath.size() - first_quotation - 1) + "\n";
 }
 
 /**
@@ -59,7 +59,7 @@ void CdCommand::cd_fn() {
         return;
    // case 2: too many arguments passed in
    } else if (num_tokens > 2) {
-        cout << "cd: Too many arguments, only write one directory!" << "\n";
+        result = "cd: Too many arguments, only write one directory!\n";
         return;
    // case 3: absolute and relative paths
     }
@@ -68,9 +68,9 @@ void CdCommand::cd_fn() {
     } catch (exception& e) {
         string error = e.what();
         if (error.find("Not a directory") != string::npos) {
-            cout << "cd: Not a directory: " << command_tokens[1] << "\n";
+            result = "cd: Not a directory: " + command_tokens[1] + "\n";
         } else if (error.find("No such file or directory") != string::npos) {
-            cout << "cd: No such file or directory: " << command_tokens[1] << "\n";
+            result = "cd: No such file or directory: " + command_tokens[1] + "\n";
         }
     }
 }
@@ -85,13 +85,13 @@ void CdCommand::cd_fn() {
  */
 void MkDirCommand::mkdir_fn() {
     if (num_tokens == 1) {
-        cout << "mkdir: Please provide a directory name." << "\n";
+        result = "mkdir: Please provide a directory name.\n";
         return;
     }
     for (size_t i = 1; i < num_tokens; i ++) {
         fs::path path_to_new_dir = fs::current_path().append(command_tokens[i]);
         if (fs::exists(path_to_new_dir)) {
-            cout << "mkdir: " << command_tokens[i] << " already exists!" << "\n";
+            result = "mkdir: " + command_tokens[i] + " already exists!" + "\n";
             return;
         }
         fs::create_directory(path_to_new_dir);
@@ -109,7 +109,7 @@ void RmCommand::rm_fn() {
     string item_type = is_rmdir ? "directory" : "file";
 
     if (num_tokens == 1) {
-        cout << command_tokens[0] << ": Please specify a " << item_type << "\n";
+        result = command_tokens[0] + ": Please specify a " + item_type + "\n";
         return;
     }
     for (size_t i = 1; i < num_tokens; i ++) {
@@ -117,20 +117,20 @@ void RmCommand::rm_fn() {
         fs::path item_to_remove = fs::current_path().append(command_tokens[i]);
 
         if (!fs::exists(item_to_remove)) {
-            cout << command_tokens[0] << ": " << item_type << " doesn't exist!" << "\n";
+            result = command_tokens[0] + ": " + item_type + " doesn't exist!" + "\n";
             return;
         } else if (command_tokens[i] == ".") {
-            cout << command_tokens[0] << ": " << "Invalid argument" << "\n";
+            result = command_tokens[0] + ": " + "Invalid argument" + "\n";
             return;
         }
 
         try {
 
             if (!is_rmdir && fs::is_directory(item_to_remove)) {
-                cout << command_tokens[0] << ": " << command_tokens[i] << " is a directory" << "\n";
+                result = command_tokens[0] + ": " + command_tokens[i] + " is a directory" + "\n";
                 return;
             } else if (is_rmdir && !fs::is_directory(item_to_remove)) {
-                cout << command_tokens[0]  << ": " << command_tokens[i] << " is not a directory" << "\n";
+                result = command_tokens[0] + ": " + command_tokens[i] + " is not a directory" + "\n";
                 return;
             }
 
@@ -140,7 +140,7 @@ void RmCommand::rm_fn() {
             string errormsg = e.what();
 
             if (errormsg.find("Directory not empty") != string::npos) {
-                cout << "rmdir: Directory not empty: " << command_tokens[1] << "\n";
+                result = "rmdir: Directory not empty: " + command_tokens[1] + "\n";
             }
         }
     }
@@ -190,7 +190,7 @@ void LsCommand::ls_fn() {
 
             // check if path to item exists
             if (!fs::exists(item_to_list)) {
-                cout << "ls: No such file or directory: " << command_tokens[i] << "\n";
+                result = result + "ls: No such file or directory: " + command_tokens[i] + "\n";
                 continue;
             }
 
@@ -203,8 +203,8 @@ void LsCommand::ls_fn() {
         }
 
         // print files first
-        cout << files_string << (files_string != "" ? "\n" : ""); // case: "ls file1 file2" output should be terminated by newline
-        cout << (files_string != "" && directories_string != "" ? "\n" : ""); // case: "ls file1 file2 dir1" output should have newline between dir and files
+        result = result + files_string + (files_string != "" ? "\n" : ""); // case: "ls file1 file2" output should be terminated by newline
+        result = result + (files_string != "" && directories_string != "" ? "\n" : ""); // case: "ls file1 file2 dir1" output should have newline between dir and files
 
         // lists of multiple directories' contents are seperated by two newlines so remove the second newline after the last directory's contents
         if (num_tokens > 2) {
@@ -212,7 +212,7 @@ void LsCommand::ls_fn() {
         }
 
         // then print directories
-        cout << directories_string;
+        result = result + directories_string;
 
         return;
     }
@@ -220,8 +220,7 @@ void LsCommand::ls_fn() {
     string list_of_items = ls_fn_helper(fs::current_path());
 
     // if input is just `ls` then call helper to simply list all the contents of current directory
-    cout << list_of_items
-        << (list_of_items == "" ? "" : "\n");;
+    result = result + list_of_items + (list_of_items == "" ? "" : "\n");
 }
 
 
@@ -237,7 +236,7 @@ void MvCommand::mv_fn() {
 
     // user has to specify a source and a target
     if (num_tokens <= 2) {
-        cout << "mv: " << "Please provide a source and target!" << "\n";
+        result = "mv: Please provide a source and target!\n";
         return;
     }
 
@@ -253,7 +252,7 @@ void MvCommand::mv_fn() {
 
             // if current iterable source doesn't exist, move on to next item
             if (!fs::exists(source)) {
-                cout << "mv: No such file or directory: " << command_tokens[i] << "\n";
+                result = result + "mv: No such file or directory: " + command_tokens[i] + "\n";
                 continue;
             }
             fs::rename(source, path_to_target / command_tokens[i]);
@@ -263,19 +262,19 @@ void MvCommand::mv_fn() {
 
     // when three or more files/dirs are given, the target should be perceived as a directory
     if (num_tokens > 3) {
-        cout << "mv: " << target << " is not a directory" << "\n";
+        result = "mv: " + target + " is not a directory\n";
         return;
     }
 
     // if source doesn't exist
     if (!fs::exists(path_to_source / command_tokens[1])) {
-        cout << "mv: No such file or directory: " + command_tokens[1] << "\n";
+        result = "mv: No such file or directory " + command_tokens[1] + "\n";
         return;
     }
 
     // edge case: when user attempts to move directory to a file
     if (fs::is_directory(path_to_source / command_tokens[1]) && fs::is_regular_file(path_to_target)) {
-        cout << "mv: " << "cannot rename a directory to name of an existing file: " << target << "\n";
+        result = "mv: cannot rename a directory to name of an existing file: " + target + "\n";
         return;
     }
 
@@ -284,26 +283,26 @@ void MvCommand::mv_fn() {
 
 void CatCommand::cat_fn() {
     if (num_tokens <= 1) {
-        cout << "cat: Not supported yet.\n";
+        result = "cat: Not supported yet.\n";
         return;
     }
     for (size_t i = 1; i < num_tokens; i++) {
         if (!fs::exists(fs::current_path() / command_tokens[i])) {
-            cout << "cat: No such file: " << command_tokens[i] << "\n";
+            result = result + "cat: No such file: " + command_tokens[i] + "\n";
             continue;
         }
 
         if (fs::is_directory(fs::current_path() / command_tokens[i])) {
-            cout << "cat: " << command_tokens[i] << " is a directory" << "\n";
+            result = result + "cat: " + command_tokens[i] + " is a directory\n";
             continue;
         }
 
-        cout << command_tokens[i] << ": \n\n";
+        result = result + command_tokens[i] + ": \n\n";
         string file_contents;
         ifstream curr_file(command_tokens[i]);
         while (getline(curr_file, file_contents)) {
-            cout << file_contents << "\n";
+            result = result + file_contents + "\n";
         }
-        cout << "\n";
+        result = result + "\n";
     }
 }

--- a/src/command.hpp
+++ b/src/command.hpp
@@ -7,6 +7,7 @@ protected:
     vector<string> command_tokens;
     size_t num_tokens;
 public:
+    string result;
     Command(vector<string> new_tokens);
     ~Command();
 };

--- a/src/luna.cpp
+++ b/src/luna.cpp
@@ -1,6 +1,11 @@
 #include "shell.hpp"
+#include "../tests/test.hpp"
 
 int main() {
+    if (getenv("LUNA_TESTING_ON")) {
+        Test test;
+        return 0; // no running shell after tests
+    }
     Shell moon;
     return 0;
 }

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -82,28 +82,36 @@ void Shell::parseUserInput(vector<string> tokens) {
     if (command == "echo") {
         EchoCommand echo(tokens);
         echo.echo_fn();
+        cout << echo.result;
         cout << "\n";
     } else if (command == "pwd") {
         PwdCommand pwd(tokens);
         pwd.pwd_fn();
+        cout << pwd.result;
     } else if (command == "cd") {
         CdCommand cd(tokens);
         cd.cd_fn();
+        cout << cd.result;
     } else if (command == "mkdir") {
         MkDirCommand mkdir(tokens);
         mkdir.mkdir_fn();
+        cout << mkdir.result;
     } else if (command == "rm" || tokens[0] == "rmdir") {
         RmCommand rm(tokens);
         rm.rm_fn();
+        cout << rm.result;
     } else if (command == "ls") {
         LsCommand ls(tokens);
         ls.ls_fn();
+        cout << ls.result;
     } else if (command == "mv") {
         MvCommand mv(tokens);
-        mv.mv_fn();    
+        mv.mv_fn();
+        cout << mv.result;
     } else if (command == "cat") {
         CatCommand cat(tokens);
         cat.cat_fn();
+        cout << cat.result;
     }
     else {
         cout << "luna.sh: command not found: " << tokens[0] << "\n";

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,0 +1,258 @@
+#include "test.hpp"
+#include <string>
+#include <iostream>
+#include <filesystem>
+namespace fs = filesystem;
+using namespace std;
+
+void Test::assert_command(string expected, string actual, string test_name) {
+    if (expected.compare(actual) == 0) number_of_tests_passed ++;
+    else cout << test_name + ": failed\nExpected: " + expected + "\nActual: " + actual << endl;
+}
+Test::Test() {
+    // create objects
+    string fullpath;
+    string repo_path = fs::current_path();
+
+    /* Echo tests */
+
+    // basic echo: `echo hello world`
+    EchoCommand test_echo({"echo", "hello", "world"});
+    test_echo.echo_fn();
+    assert_command("hello world ", test_echo.result, "Basic echo");
+
+    // empty echo: `echo`
+    test_echo = EchoCommand({"echo"});
+    test_echo.echo_fn();
+    assert_command("", test_echo.result, "Empty echo");
+
+    /* Pwd tests */
+
+    // basic pwd: `pwd`
+    PwdCommand test_pwd({"pwd"});
+    test_pwd.pwd_fn();
+    fullpath = fs::current_path();
+    size_t rootdir = fullpath.find("moon.sh");
+    if (!test_pwd.result.find(fullpath.substr(rootdir))) cout << "Basic pwd: failed.\n" << "Expected: " << fullpath << "\nActual: " << test_pwd.result << endl;
+    else number_of_tests_passed ++;
+
+    // pwd with parameters: `pwd no!`
+    test_pwd = PwdCommand({"pwd", "no!"});
+    test_pwd.pwd_fn();
+    assert_command("pwd: Only write pwd!\n", test_pwd.result, "pwd with parameters");
+
+    /* Cd tests */
+
+    // empty cd: `cd`
+    CdCommand test_cd({"cd"});
+    test_cd.cd_fn();
+    fullpath = fs::current_path();
+    assert_command(getenv("HOME"), fullpath, "Empty cd");
+
+    fs::current_path(repo_path);
+
+    // cd with multiple parameters: `cd dir1 dir2`
+    test_cd = CdCommand({"cd", "dir1", "dir2"});
+    test_cd.cd_fn();
+    assert_command("cd: Too many arguments, only write one directory!\n", test_cd.result, "cd with multiple parameters");
+
+    // cd to directory: `cd ../tests`
+    test_cd = CdCommand({"cd", "../tests"});
+    test_cd.cd_fn();
+    fullpath = fs::current_path();
+    rootdir = fullpath.find("tests");
+    if (rootdir == string::npos) cout << "cd to directory: failed" << endl;
+    else number_of_tests_passed ++;
+
+    // cd on non-existent item: `cd nonexistent`
+    test_cd = CdCommand({"cd", "nonexistent"});
+    test_cd.cd_fn();
+    fullpath = fs::current_path();
+    assert_command("cd: No such file or directory: nonexistent\n", test_cd.result, "cd on non-existent directory");
+
+    fs::current_path(repo_path);
+
+    // cd on file: `cd luna.sh`
+    test_cd = CdCommand({"cd", "luna.sh"});
+    test_cd.cd_fn();
+    fullpath = fs::current_path();
+    assert_command("cd: Not a directory: luna.sh\n", test_cd.result, "cd on file");
+
+    /* MkDir tests */
+
+    // empty mkdir: `mkdir`
+    MkDirCommand test_mkdir = MkDirCommand({"mkdir"});
+    test_mkdir.mkdir_fn();
+    assert_command("mkdir: Please provide a directory name.\n", test_mkdir.result, "mkdir with no arguments");
+
+    // basic mkdir: `mkdir hello world`
+    test_mkdir = MkDirCommand({"mkdir", "hello", "world"});
+    test_mkdir.mkdir_fn();
+    if (!fs::exists("hello") && fs::exists("world")) cout << "basic mkdir failed" << endl;
+    else number_of_tests_passed ++;
+
+    // mkdir on existing directory: `mkdir hello`
+    test_mkdir = MkDirCommand({"mkdir", "hello"});
+    test_mkdir.mkdir_fn();
+    assert_command("mkdir: hello already exists!\n", test_mkdir.result, "mkdir on existing directory");
+
+    /* Rm/Rmdir tests */
+
+    // empty rm: `rm`
+    RmCommand test_rm({"rm"});
+    test_rm.rm_fn();
+    assert_command("rm: Please specify a file\n", test_rm.result, "rm with no arguments");
+
+    // empty rmdir: `rmdir`
+    test_rm = RmCommand({"rmdir"});
+    test_rm.rm_fn();
+    assert_command("rmdir: Please specify a directory\n", test_rm.result, "rmdir with no arguments");
+
+    // rm on nonexistent item: `rm nonexistent`
+    test_rm = RmCommand({"rm", "nonexistent"});
+    test_rm.rm_fn();
+    assert_command("rm: file doesn't exist!\n", test_rm.result, "rm with nonexistent file");
+
+    // rmdir on nonexistent item: `rmdir nonexistent`
+    test_rm = RmCommand({"rmdir", "nonexistent"});
+    test_rm.rm_fn();
+    assert_command("rmdir: directory doesn't exist!\n", test_rm.result, "rm with nonexistent directory");
+
+    // rm on current directory: `rm .`
+    test_rm = RmCommand({"rm", "."});
+    test_rm.rm_fn();
+    assert_command("rm: Invalid argument\n", test_rm.result, "rm on current directory");
+
+    // rmdir on current directory: `rmdir .`
+    test_rm = RmCommand({"rmdir", "."});
+    test_rm.rm_fn();
+    assert_command("rmdir: Invalid argument\n", test_rm.result, "rmdir on current directory");
+
+    // rm on directory: `rm hello`
+    test_rm = RmCommand({"rm", "hello"});
+    test_rm.rm_fn();
+    assert_command("rm: hello is a directory\n", test_rm.result, "rm on directory");
+
+    // rmdir on file: `rmdir command.cpp`
+    test_rm = RmCommand({"rmdir", "command.cpp"});
+    test_rm.rm_fn();
+    assert_command("rmdir: command.cpp is not a directory\n", test_rm.result, "rmdir on file");
+
+    // rmdir on directories: `rmdir hello world`
+    test_rm = RmCommand({"rmdir", "hello", "world"});
+    test_rm.rm_fn();
+    if (fs::exists("hello") || fs::exists("world")) cout << "rmdir on directories: failed" << endl;
+    else number_of_tests_passed ++;
+
+    // rm on files: `rm command.cpp command.hpp`
+    test_rm = RmCommand({"rm", "command.cpp", "command.hpp"});
+    test_rm.rm_fn();
+    if (fs::exists("command.cpp") || fs::exists("command.hpp")) cout << "rm on files: failed" << endl;
+    else number_of_tests_passed ++;
+
+    // rmdir on non-empty directory: `rm ../tests`
+    test_rm = RmCommand({"rmdir", "../tests"});
+    test_rm.rm_fn();
+    assert_command("rmdir: Directory not empty: ../tests\n", test_rm.result, "rmdir on non-empty directory");
+
+    /* Ls tests */
+
+    // basic ls: `ls`
+    LsCommand test_ls({"ls"});
+    test_ls.ls_fn();
+    assert_command("shell.hpp    luna.cpp    luna.sh    mv_test_dir    shell.cpp    \n", test_ls.result, "basic ls");
+
+    // ls on file: `ls luna.cpp`
+    test_ls = LsCommand({"ls", "luna.cpp"});
+    test_ls.ls_fn();
+    assert_command("luna.cpp    \n", test_ls.result, "ls on file");
+
+    // ls on explicit directory: `ls ../tests`
+    test_ls = LsCommand({"ls", "../tests"});
+    test_ls.ls_fn();
+    assert_command("../tests/: \ntest.cpp    test.hpp    \n", test_ls.result, "ls on directory");
+
+    // ls on multiple directories: `ls ../tests .`
+    test_ls = LsCommand({"ls", "../tests", "."});
+    test_ls.ls_fn();
+    assert_command("../tests/: \ntest.cpp    test.hpp    \n\n./: \nshell.hpp    luna.cpp    luna.sh    mv_test_dir    shell.cpp    \n",
+                        test_ls.result, "ls on directories");
+
+    // ls on files and directories: `ls luna.cpp ../tests . luna.sh`
+    test_ls = LsCommand({"ls", "luna.cpp", "../tests", ".", "luna.sh"});
+    test_ls.ls_fn();
+    assert_command("luna.cpp    luna.sh    \n\n../tests/: \ntest.cpp    test.hpp    \n\n./: \nshell.hpp    luna.cpp    luna.sh    mv_test_dir    shell.cpp    \n",
+                        test_ls.result, "ls on files and directories");
+
+    // ls on nonexistent item: `ls nonexistent`
+    test_ls = LsCommand({"ls", "nonexistent"});
+    test_ls.ls_fn();
+    assert_command("ls: No such file or directory: nonexistent\n", test_ls.result, "ls on nonexistent item");
+
+    // ls on nonexistent and existent item without termination: `ls nonexistent ../tests`
+    test_ls = LsCommand({"ls", "nonexistent", "../tests"});
+    test_ls.ls_fn();
+    assert_command("ls: No such file or directory: nonexistent\n../tests/: \ntest.cpp    test.hpp    \n",
+                        test_ls.result, "ls on nonexistent and existent items without termination");
+
+    /* Mv tests */
+
+    // mv with insufficient arguments: `mv luna.sh`
+    MvCommand test_mv({"mv", "luna.sh"});
+    test_mv.mv_fn();
+    assert_command("mv: Please provide a source and target!\n", test_mv.result, "mv on less than 3 items");
+
+    // mv on multiple files to non-directory item: `mv luna.sh luna.cpp command.cpp`
+    test_mv = MvCommand({"mv", "luna.sh", "luna.cpp", "command.cpp"});
+    test_mv.mv_fn();
+    assert_command("mv: command.cpp is not a directory\n", test_mv.result, "mv on multiple files to non-directory target");
+
+    // mv on files to a target directory: `mv luna.sh luna.cpp ../tests`
+    test_mv = MvCommand({"mv", "luna.sh", "luna.cpp", "../tests"});
+    test_mv.mv_fn();
+    if (!fs::exists("../tests/luna.sh") && !fs::exists("../tests/luna.cpp")) cout << "mv: moving files to directory: failed" << endl;
+    else number_of_tests_passed ++;
+
+    // mv a directory to a file: `mv ../tests/shell.cpp`
+    test_mv = MvCommand({"mv", "../tests", "shell.cpp"});
+    test_mv.mv_fn();
+    assert_command("mv: cannot rename a directory to name of an existing file: shell.cpp\n", test_mv.result, "mv on directory to a file");
+
+    // mv usage to rename a file: `mv shell.cpp new_name.cpp`
+    test_mv = MvCommand({"mv", "shell.cpp", "new_name.cpp"});
+    test_mv.mv_fn();
+    if (!fs::exists("new_name.cpp") && fs::exists("shell.cpp")) cout << "mv: renaming a file: failed" << endl;
+    else number_of_tests_passed ++;
+
+    // mv a directory to another directory `mv mv_test_dir ..`
+    test_mv = MvCommand({"mv", "mv_test_dir", ".."});
+    test_mv.mv_fn();
+    if (!fs::exists("../mv_test_dir")) cout << "mv: moving one directory to another: failed" << endl;
+    else number_of_tests_passed ++;
+
+    /* Cat tests */
+
+    // empty cat: `cat`
+    CatCommand test_cat({"cat"});
+    test_cat.cat_fn();
+    assert_command("cat: Not supported yet.\n", test_cat.result, "empty cat");
+
+    // cat on nonexistent item: `cat nonexistent`
+    test_cat = CatCommand({"cat", "nonexistent"});
+    test_cat.cat_fn();
+    assert_command("cat: No such file: nonexistent\n", test_cat.result, "cat on nonexistent item");
+
+    // cat on directory: `cat ../src`
+    test_cat = CatCommand({"cat", "../src"});
+    test_cat.cat_fn();
+    assert_command("cat: ../src is a directory\n", test_cat.result, "cat on directory");
+
+    // cat on file: `cat ../cat_testing.txt`
+    test_cat = CatCommand({"cat", "../cat_testing.txt"});
+    test_cat.cat_fn();
+    assert_command("../cat_testing.txt: \n\nHello world\n\n\n", test_cat.result, "cat on a file");
+
+    cout << number_of_tests_passed << "/40 passed" << endl;
+}
+
+Test::~Test() {};

--- a/tests/test.hpp
+++ b/tests/test.hpp
@@ -1,0 +1,9 @@
+#include "../src/command.hpp"
+class Test {
+protected:
+    void assert_command(string expected, string actual, string test_name);
+    int number_of_tests_passed = 0;
+public:
+    Test();
+    ~Test();
+};


### PR DESCRIPTION
Added some test suites through OOP in the `tests` directory. A new startup option called "--testing" is available. When enabled, the test suites will be ran and the shell will be terminated. To improve the software design, a new string attribute called `result` has been added to command classes. This member variable stores the output of commands even if it's a failure message. The test suites are used to test against these `result` strings.