### PR TITLE
refactor: Apply reference-to-const parameters in most functions.

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -5,7 +5,7 @@
 #include "command.hpp"
 namespace fs = filesystem;
 
-Command::Command(vector<string> new_tokens) {
+Command::Command(const vector<string>& new_tokens) {
     command_tokens = new_tokens;
     num_tokens = new_tokens.size();
 }
@@ -284,7 +284,7 @@ void MvCommand::mv_fn() {
 /**
  * @brief Display contents of a file.
  *
- * This function handles user input for the `cat` command. It is used 
+ * This function handles user input for the `cat` command. It is used
  * to list contents of the file arguments.
  *
  */

--- a/src/command.hpp
+++ b/src/command.hpp
@@ -8,31 +8,31 @@ protected:
     size_t num_tokens;
 public:
     string result;
-    Command(vector<string> new_tokens);
+    Command(const vector<string>& new_tokens);
     ~Command();
 };
 
 class EchoCommand : public Command {
 public:
-    EchoCommand(vector<string> new_tokens) : Command (new_tokens) {};
+    EchoCommand(const vector<string>& new_tokens) : Command (new_tokens) {};
     void echo_fn();
 };
 
 class PwdCommand : public Command {
 public:
-    PwdCommand(vector<string> new_tokens) : Command (new_tokens) {};
+    PwdCommand(const vector<string>& new_tokens) : Command (new_tokens) {};
     void pwd_fn();
 };
 
 class CdCommand : public Command {
 public:
-    CdCommand(vector<string> new_tokens) : Command (new_tokens) {};
+    CdCommand(const vector<string>& new_tokens) : Command (new_tokens) {};
     void cd_fn();
 };
 
 class MkDirCommand : public Command {
 public:
-    MkDirCommand(vector<string> new_tokens) : Command (new_tokens) {};
+    MkDirCommand(const vector<string>& new_tokens) : Command (new_tokens) {};
     void mkdir_fn();
 };
 
@@ -40,7 +40,7 @@ class RmCommand : public Command {
 private:
     bool is_rmdir;
 public:
-    RmCommand(vector<string> new_tokens) : Command (new_tokens) {
+    RmCommand(const vector<string>& new_tokens) : Command (new_tokens) {
         is_rmdir = new_tokens[0] == "rmdir" ? true : false;
     };
     void rm_fn();
@@ -48,18 +48,18 @@ public:
 
 class LsCommand : public Command {
 public:
-    LsCommand(vector<string> new_tokens) : Command (new_tokens) {};
+    LsCommand(const vector<string>& new_tokens) : Command (new_tokens) {};
     void ls_fn();
 };
 
 class MvCommand : public Command {
 public:
-    MvCommand(vector<string> new_tokens) : Command (new_tokens) {};
+    MvCommand(const vector<string>& new_tokens) : Command (new_tokens) {};
     void mv_fn();
 };
 
 class CatCommand : public Command {
 public:
-    CatCommand(vector<string> new_tokens) : Command (new_tokens) {};
+    CatCommand(const vector<string>& new_tokens) : Command (new_tokens) {};
     void cat_fn();
 };

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -4,7 +4,7 @@
 #include "command.hpp"
 
 Shell::Shell() {
-    cout << "Welcome to luna.sh!\n";
+    cout << "Welcome to luna.sh!" << endl;
     while(true) {
         cout << "luna $ ";
 
@@ -77,13 +77,12 @@ vector<string> Shell::tokenize() {
  *
  * @return vector of tokens for command parsing
  */
-void Shell::parseUserInput(vector<string> tokens) {
+void Shell::parseUserInput(const vector<string>& tokens) {
     string command = tokens[0];
     if (command == "echo") {
         EchoCommand echo(tokens);
         echo.echo_fn();
-        cout << echo.result;
-        cout << "\n";
+        cout << echo.result << endl;
     } else if (command == "pwd") {
         PwdCommand pwd(tokens);
         pwd.pwd_fn();
@@ -114,6 +113,6 @@ void Shell::parseUserInput(vector<string> tokens) {
         cout << cat.result;
     }
     else {
-        cout << "luna.sh: command not found: " << tokens[0] << "\n";
+        cout << "luna.sh: command not found: " << tokens[0] << endl;
     }
 }

--- a/src/shell.hpp
+++ b/src/shell.hpp
@@ -6,7 +6,7 @@ class Shell
 private:
     string command;
     vector<string> tokenize();
-    void parseUserInput(vector<string> tokens);
+    void parseUserInput(const vector<string>& tokens);
 public:
     Shell();
     ~Shell();

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -5,7 +5,7 @@
 namespace fs = filesystem;
 using namespace std;
 
-void Test::assert_command(string expected, string actual, string test_name) {
+void Test::assert_command(const string& expected, const string& actual, const string& test_name) {
     if (expected.compare(actual) == 0) number_of_tests_passed ++;
     else cout << test_name + ": failed\nExpected: " + expected + "\nActual: " + actual << endl;
 }

--- a/tests/test.hpp
+++ b/tests/test.hpp
@@ -1,7 +1,7 @@
 #include "../src/command.hpp"
 class Test {
 protected:
-    void assert_command(string expected, string actual, string test_name);
+    void assert_command(const string& expected, const string& actual, const string& test_name);
     int number_of_tests_passed = 0;
 public:
     Test();


### PR DESCRIPTION
This conserves some memory as copies of the arguments aren't made in the function call stack and makes it clear to not mutate any user input command tokens.