### PR TITLE
refactor: Applied new `current_path` member variable to `Command` class.

### DIFF
--- a/src/command.hpp
+++ b/src/command.hpp
@@ -1,11 +1,14 @@
 #include <string>
 #include <vector>
+#include <filesystem>
 using namespace std;
+namespace fs = filesystem;
 
 class Command {
 protected:
     vector<string> command_tokens;
     size_t num_tokens;
+    string current_path;
 public:
     string result;
     Command(const vector<string>& new_tokens);


### PR DESCRIPTION
This new attribute is set to the `fs::current_path()` output, which is the full path to the current directory the user is on. Given that many commands refer to the current path, it is ideal to introduce this attribute to limit the function calls to get said path to just once.

Additionally, a small refactor to the `cat` function was made.