### PR TITLE
 feat: Implement wc with options support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ luna: ${BUILDDIR}/luna.sh
 
 # Target for testing
 testing: luna.sh
-	@echo "Running testing..."
+	@echo "Running tests..."
 	@echo "Hello world" >> build/cat_testing.txt
 	@mkdir -p ${BUILDDIR}/mv_test_dir
 	@(cd ${BUILDDIR} && export ${TEST_MODE_ENV} && export DYLD_LIBRARY_PATH=${CONDA_PREFIX}/lib:${DYLD_LIBRARY_PATH} && ./$<)

--- a/include/command.hpp
+++ b/include/command.hpp
@@ -81,8 +81,8 @@ public:
 
 class WcCommand : public Command {
 private:
-    void append_count_to_result(int current_word_count, int current_line_count, int current_character_count);
+    void append_count_to_result(const int& current_word_count, const int& current_line_count, const int& current_character_count);
+    void wc_fn();
 public:
     WcCommand(const vector<string>& new_tokens);
-    void wc_fn();
 };

--- a/include/command.hpp
+++ b/include/command.hpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <vector>
 #include <filesystem>
+#include <unordered_map>
 using namespace std;
 namespace fs = filesystem;
 
@@ -8,7 +9,18 @@ class Command {
 protected:
     string current_path;
     size_t num_tokens;
+    void set_command_options(const string& options_token);
+    void options_handler();
+    void disable_all_options();
+
+    // boolean to support disabling all the options if any is explicitly filtered in user input
+    bool disable_all_options_if_explicit_found = true;
+
+    // boolean flag to check if an invalid option is found, where command functionality terminates
+    bool invalid_option_found = false;
+
 public:
+    unordered_map<char, bool> command_options;
     vector<string> command_tokens;
     string result;
     Command(const vector<string>& new_tokens);
@@ -65,4 +77,12 @@ class CatCommand : public Command {
 public:
     CatCommand(const vector<string>& new_tokens) : Command (new_tokens) {};
     void cat_fn();
+};
+
+class WcCommand : public Command {
+private:
+    void append_count_to_result(int current_word_count, int current_line_count, int current_character_count);
+public:
+    WcCommand(const vector<string>& new_tokens);
+    void wc_fn();
 };

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -8,6 +8,39 @@ Command::Command(const vector<string>& new_tokens) {
     current_path += "/"; // directory suffix
 }
 
+void Command::disable_all_options() {
+    for (auto& option : command_options) {
+        option.second = false; // disable all options to false
+    }
+}
+
+void Command::set_command_options(const string& options_token) {
+    for (char option : options_token) {
+        if (option == '-') continue; //skip the option indicator
+
+        if (command_options.find(option) != command_options.end()) command_options[option] = true;
+        else {
+            result += command_tokens[0] + ": illegal option: " + option + "\n";
+            invalid_option_found = true;
+            return;
+        }
+    }
+}
+
+void Command::options_handler() {
+    // search for options (which are prefixed by '-')
+    for (string token : command_tokens) {
+        if (token[0] != '-') continue;
+
+        if (disable_all_options_if_explicit_found == true) {
+            disable_all_options();
+            disable_all_options_if_explicit_found = false;
+        }
+
+        set_command_options(token);
+    }
+}
+
 Command::~Command() {
     /* Clean up resources */
 }

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -8,12 +8,36 @@ Command::Command(const vector<string>& new_tokens) {
     current_path += "/"; // directory suffix
 }
 
+/**
+ * @brief helper function to disable all options
+ *
+ * This function is called in the option handling process
+ * whenever any option has been explicitly mentioned in user
+ * input. This disables any options that are part of the
+ * default behaviour of the command (when options are not
+ * defined in input).
+ *
+ */
 void Command::disable_all_options() {
     for (auto& option : command_options) {
         option.second = false; // disable all options to false
     }
 }
 
+/**
+ * @brief helper function to enable filtered options
+ *
+ * This function is called in the option handling process
+ * to enable the inputted options by setting them to true in the
+ * command_options map. This will lay out the behaviour of the
+ * command based on the options selected. If there is an illegal
+ * option found, a flag for invalid option is set to true and
+ * then the function terminates. This flag, when true, will prevent
+ * the main command functionality (i.e wc_fn()) to execute.
+ *
+ * @param curr_path: a string that represents a token defined as an option
+ *
+ */
 void Command::set_command_options(const string& options_token) {
     for (char option : options_token) {
         if (option == '-') continue; //skip the option indicator
@@ -27,6 +51,14 @@ void Command::set_command_options(const string& options_token) {
     }
 }
 
+/**
+ * @brief function used for handling options
+ *
+ * This function handles input involving any options (prefixed
+ * by '-'). It calls the helper functions above to address
+ * various cases that can come with user input options.
+ *
+ */
 void Command::options_handler() {
     // search for options (which are prefixed by '-')
     for (string token : command_tokens) {

--- a/src/commands/wc.cpp
+++ b/src/commands/wc.cpp
@@ -1,0 +1,76 @@
+#include <fstream>
+#include <string>
+#include <sstream>
+#include "../../include/command.hpp"
+
+
+WcCommand::WcCommand(const vector<string>& new_tokens) : Command (new_tokens) {
+    command_options['l'] = true, command_options['w'] = true; command_options['c'] = true;
+    options_handler();
+    if (!invalid_option_found) wc_fn();
+};
+
+void wc_counter(ifstream& file_to_count_from, int& word_count, int& line_count, int& character_count) {
+    string line_to_read;
+    while (getline(file_to_count_from, line_to_read)) {
+        stringstream ss(line_to_read);
+        string curr_word;
+        line_count ++;
+        character_count += line_to_read.length() + 1; // include the newline
+        while (ss >> curr_word) {
+            word_count ++;
+        }
+    }
+}
+
+void WcCommand::append_count_to_result(int current_word_count, int current_line_count, int current_character_count) {
+    result +=
+    (command_options.empty() || command_options['l'] == true ? "\t" + to_string(current_line_count) : "") +
+    (command_options.empty() || command_options['w'] == true ? "\t" + to_string(current_word_count): "") +
+    (command_options.empty() || command_options['c'] == true ? "\t" + to_string(current_character_count): "");
+}
+
+void WcCommand::wc_fn() {
+    if (num_tokens == 1) {
+        result = "wc: Not supported yet\n";
+        return;
+    }
+    int current_word_count, current_line_count, current_character_count;
+
+    int total_word_count = 0, total_line_count = 0, total_character_count = 0;
+    for (size_t i = 1; i < num_tokens; i++) {
+        current_word_count = 0, current_line_count = 0, current_character_count = 0;
+
+        if (command_tokens[i][0] == '-') {
+            continue; // skip option tokens;
+        }
+        else if(fs::is_directory(command_tokens[i])) {
+            result += "wc: " + command_tokens[i] + " is a directory.\n";
+            continue;
+        } else if (!fs::exists(command_tokens[i])) {
+            result += "wc: " + command_tokens[i] + ": No such file or directory.\n";
+            continue;
+        }
+
+        ifstream input_file(command_tokens[i]);
+        if (input_file.is_open()) {
+            wc_counter(input_file, current_word_count, current_line_count, current_character_count);
+            input_file.close();
+        } else {
+            result += "wc: unable to open file: " + command_tokens[i] + "\n";
+        }
+
+        append_count_to_result(current_word_count, current_line_count, current_character_count);
+        result += " " + command_tokens[i] + "\n";
+
+        total_character_count += current_character_count;
+        total_word_count += current_word_count;
+        total_line_count += current_line_count;
+    }
+
+    if (total_word_count != current_word_count) { // signifies that there are multiple files counted from so total word count must be greater
+        append_count_to_result(total_word_count, total_line_count, total_character_count);
+        result += " total\n";
+    }
+
+}

--- a/src/commands/wc.cpp
+++ b/src/commands/wc.cpp
@@ -3,13 +3,33 @@
 #include <sstream>
 #include "../../include/command.hpp"
 
-
+// constructor for WcCommand objects
 WcCommand::WcCommand(const vector<string>& new_tokens) : Command (new_tokens) {
+    // set all options to true by default
     command_options['l'] = true, command_options['w'] = true; command_options['c'] = true;
+
+    // handle any user input options
     options_handler();
+
+    // if an illegal option is not found, then continue with main command functionality
     if (!invalid_option_found) wc_fn();
 };
 
+/**
+ * @brief helper function to count words, characters and lines of a file.
+ *
+ * This function counts words, characters and lines from the input file,
+ * file_to_count_from. It takes the three types of counts as references
+ * in order to change them in-place.
+ *
+ * @params:
+ *  - file_to_count_from: an input file stream to count words,
+ *       characters, and lines from
+ *  - word_count: an integer representing word count of the file
+ *  - line_count: an integer representing line count of the file
+ *  - character_count: an integer representing character count of the file
+ *
+ */
 void wc_counter(ifstream& file_to_count_from, int& word_count, int& line_count, int& character_count) {
     string line_to_read;
     while (getline(file_to_count_from, line_to_read)) {
@@ -23,13 +43,36 @@ void wc_counter(ifstream& file_to_count_from, int& word_count, int& line_count, 
     }
 }
 
-void WcCommand::append_count_to_result(int current_word_count, int current_line_count, int current_character_count) {
+/**
+ * @brief helper method to append count outputs to `result` string.
+ *
+ * This function formats and appends the results from counting through
+ * a file to the `results` string which will be the output.
+ *
+ * @params:
+ *      - current_word_count: an integer representing word count of the current file
+ *      - current_line_count: an integer representing line count of the current file
+ *      - current_character_count: an integer representing character count of the current file
+ *
+ */
+void WcCommand::append_count_to_result(const int& current_word_count, const int& current_line_count, const int& current_character_count) {
     result +=
     (command_options.empty() || command_options['l'] == true ? "\t" + to_string(current_line_count) : "") +
     (command_options.empty() || command_options['w'] == true ? "\t" + to_string(current_word_count): "") +
     (command_options.empty() || command_options['c'] == true ? "\t" + to_string(current_character_count): "");
 }
 
+/**
+ * @brief Count words, characters, and/or lines of an input file.
+ *
+ * This function counts the words, characters, and/or lines of an input file,
+ * handling any explicit options from user input and any invalid input. It
+ * supports three options: `-l` for counting lines, `-w` for counting words
+ * and `-c` for counting characters. If no options are defined, then it will
+ * default to displaying all three counts
+ *
+ *
+ */
 void WcCommand::wc_fn() {
     if (num_tokens == 1) {
         result = "wc: Not supported yet\n";
@@ -68,7 +111,7 @@ void WcCommand::wc_fn() {
         total_line_count += current_line_count;
     }
 
-    if (total_word_count != current_word_count) { // signifies that there are multiple files counted from so total word count must be greater
+    if (total_word_count > current_word_count) { // signifies that there are multiple files counted from so total word count must be greater
         append_count_to_result(total_word_count, total_line_count, total_character_count);
         result += " total\n";
     }

--- a/src/shell.cpp
+++ b/src/shell.cpp
@@ -143,6 +143,10 @@ void Shell::parseUserInput(const vector<string>& tokens) {
         cat.cat_fn();
         command_history.insert_command(cat);
         cout << cat.result;
+    } else if (command == "wc") {
+        WcCommand wc(tokens);
+        command_history.insert_command(wc);
+        cout << wc.result;
     } else {
         cout << "luna.sh: command not found: " << tokens[0] << endl;
     }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -250,7 +250,42 @@ Test::Test() {
     test_cat.cat_fn();
     assert_command("../cat_testing.txt: \n\nHello world\n\n", test_cat.result, "cat on a file");
 
-    cout << number_of_tests_passed << "/40 passed" << endl;
+    WcCommand test_wc({"wc"});
+    assert_command("wc: Not supported yet\n", test_wc.result, "empty wc");
+
+    test_wc = WcCommand({"wc", "command-history.cpp"});
+    assert_command("	144	597	4412 command-history.cpp\n", test_wc.result, "wc on a file");
+
+    test_wc = WcCommand({"wc", "command-history.cpp", "../tests/luna.cpp"});
+    assert_command("	144	597	4412 command-history.cpp\n	11	26	221 ../tests/luna.cpp\n	155	623	4633 total\n",
+        test_wc.result, "wc on multiple files");
+
+    test_wc = WcCommand({"wc", "../mv_test_dir"});
+    assert_command("wc: ../mv_test_dir is a directory.\n", test_wc.result, "wc on a directory");
+
+    test_wc = WcCommand({"wc", "non-existent"});
+    assert_command("wc: non-existent: No such file or directory.\n", test_wc.result, "wc on a non-existent item");
+
+    test_wc = WcCommand({"wc", "-l", "command-history.cpp", "../tests/luna.cpp"});
+    assert_command("	144 command-history.cpp\n	11 ../tests/luna.cpp\n	155 total\n",
+        test_wc.result, "wc with -l option");
+
+    test_wc = WcCommand({"wc", "-w", "command-history.cpp", "../tests/luna.cpp"});
+    assert_command("	597 command-history.cpp\n	26 ../tests/luna.cpp\n	623 total\n",
+        test_wc.result, "wc with -w option");
+
+    test_wc = WcCommand({"wc", "-c", "command-history.cpp", "../tests/luna.cpp"});
+    assert_command("	4412 command-history.cpp\n	221 ../tests/luna.cpp\n	4633 total\n",
+        test_wc.result, "wc with -c option");
+
+    test_wc = WcCommand({"wc", "-l", "-w", "command-history.cpp", "../tests/luna.cpp"});
+    assert_command("	144	597 command-history.cpp\n	11	26 ../tests/luna.cpp\n	155	623 total\n",
+        test_wc.result, "wc with multiple options");
+
+    test_wc = WcCommand({"wc", "-lc", "command-history.cpp", "../tests/luna.cpp"});
+    assert_command("	144	4412 command-history.cpp\n	11	221 ../tests/luna.cpp\n	155	4633 total\n",
+        test_wc.result, "wc with multiple options defined together under one '-' ");
+    cout << number_of_tests_passed << "/50 passed" << endl;
 }
 
 Test::~Test() {};


### PR DESCRIPTION
`wc` is now supported along with following flags: '-w', '-l',
and '-c'. As this is the first command with options support,
there has been some new members appended to the base Command
class that handles options.